### PR TITLE
fix: Remove unused spacing imports from path screens

### DIFF
--- a/src/screens/mental/MentalHealthPath.tsx
+++ b/src/screens/mental/MentalHealthPath.tsx
@@ -4,7 +4,6 @@ import { Text } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '../../theme/colors';
 import { typography, shadows } from '../../theme/theme';
-import { spacing } from '../../theme/spacing';
 import { MentalFoundation, MentalLesson, MENTAL_FOUNDATIONS } from '../../types/mental';
 import { useAuthStore } from '../../store/authStore';
 import { getCompletedLessons } from '../../database/lessons';

--- a/src/screens/nutrition/NutritionPath.tsx
+++ b/src/screens/nutrition/NutritionPath.tsx
@@ -4,7 +4,6 @@ import { Text } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '../../theme/colors';
 import { typography, shadows } from '../../theme/theme';
-import { spacing } from '../../theme/spacing';
 import { NutritionFoundation, NutritionLesson, NUTRITION_FOUNDATIONS, NUTRITION_TOOLS } from '../../types/nutrition';
 import { useAuthStore } from '../../store/authStore';
 import { getCompletedLessons } from '../../database/lessons';

--- a/src/screens/physical/PhysicalHealthPath.tsx
+++ b/src/screens/physical/PhysicalHealthPath.tsx
@@ -4,7 +4,6 @@ import { Text } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '../../theme/colors';
 import { typography, shadows } from '../../theme/theme';
-import { spacing } from '../../theme/spacing';
 import { PhysicalFoundation, PhysicalLesson, PHYSICAL_FOUNDATIONS } from '../../types/physical';
 import { useAuthStore } from '../../store/authStore';
 import { getCompletedLessons } from '../../database/lessons';


### PR DESCRIPTION
Remove unused 'spacing' import from Mental, Physical, and Nutrition path screens. This import was added but never used in the code, which could cause bundler confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)