### PR TITLE
fix: Add web-safe notifications stub to prevent white screen on web

### DIFF
--- a/src/utils/notifications.web.ts
+++ b/src/utils/notifications.web.ts
@@ -1,0 +1,56 @@
+// Web stub for notifications - notifications don't work on web platform
+// This file prevents crashes when importing notifications in web builds
+
+/**
+ * Request notification permissions (Web stub - always returns false)
+ */
+export const requestNotificationPermissions = async (): Promise<boolean> => {
+  console.log('🌐 Notifications not supported on web platform');
+  return false;
+};
+
+/**
+ * Schedule streak protection notification (Web stub - no-op)
+ */
+export const scheduleStreakProtectionNotification = async (): Promise<void> => {
+  console.log('🌐 Notifications not supported on web platform');
+};
+
+/**
+ * Schedule daily reminder at specific time (Web stub - no-op)
+ */
+export const scheduleDailyReminder = async (hour: number, minute: number): Promise<void> => {
+  console.log('🌐 Notifications not supported on web platform');
+};
+
+/**
+ * Cancel daily reminder (Web stub - no-op)
+ */
+export const cancelDailyReminder = async (): Promise<void> => {
+  console.log('🌐 Notifications not supported on web platform');
+};
+
+/**
+ * Schedule immediate notification (Web stub - no-op)
+ */
+export const scheduleImmediateNotification = async (
+  title: string,
+  body: string,
+  data?: any
+): Promise<void> => {
+  console.log('🌐 Notifications not supported on web platform');
+};
+
+/**
+ * Cancel all scheduled notifications (Web stub - no-op)
+ */
+export const cancelAllScheduledNotifications = async (): Promise<void> => {
+  console.log('🌐 Notifications not supported on web platform');
+};
+
+/**
+ * Initialize notifications system (Web stub - no-op)
+ */
+export const initializeNotifications = async (): Promise<void> => {
+  console.log('🌐 Notifications not supported on web platform - skipping initialization');
+};


### PR DESCRIPTION
Issue: Expo notifications API causes crash on web platform
- notifications.ts calls Notifications.setNotificationHandler() at import time
- This fails on web platform causing white screen

Solution: Create notifications.web.ts with safe stub implementations
- All notification functions return no-op on web
- Prevents import-time crashes
- Maintains API compatibility

This fixes the white screen issue on https://lifequest-app.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)